### PR TITLE
dask cluster defaults: pangeo-notebook workers & 20 minute timeout

### DIFF
--- a/daskhub/values.yaml
+++ b/daskhub/values.yaml
@@ -305,7 +305,7 @@ daskhub:
                   Mapping("env_items", default={}, label="Environment Variables"),
                   String("scheduler_memory", default="22.5 G", label="Scheduler Memory"),
                   Float("scheduler_cores", default=3.7, min=1, max=8, label="Scheduler CPUs"),
-                  Float("idle_timeout", default=300, min=0, label="Idle Timeout (s)"),
+                  Float("idle_timeout", default=1200, min=0, label="Idle Timeout (s)"),
                   # AMM may become default in the future and we can remove this option
                   # or modify it to allow different policies
                   Bool("active_memory_manager", default=True, label="Enable experimental active memory manager"),

--- a/daskhub/values.yaml
+++ b/daskhub/values.yaml
@@ -295,7 +295,7 @@ daskhub:
                       label="Cluster Memory Size"
                   ),
                   Float("cpus", default=1.0, min=1.0, max=7.0, label="Worker CPUs"),
-                  String("worker_image", default="pangeo/base-notebook:2022.11.03", label="Worker Image"),
+                  String("worker_image", default="pangeo/pangeo-notebook:2022.11.03", label="Worker Image"),
                   String("scheduler_image", default="pangeo/base-notebook:2022.11.03", label="Scheduler Image"),
                   String("extra_pip_packages", default="", label="Extra pip Packages"),
                   String("gcsfuse_tokens", default="", label="GCSFUSE Tokens"),


### PR DESCRIPTION
workers need pangeo-y stuff e.g. xarray to work their work

this also changes the default dask-cluster `idle_timeout` to 20 minutes from 5 cuz 5 was annoying