### PR TITLE
Fix the Integer import in the last PR

### DIFF
--- a/daskhub/values.yaml
+++ b/daskhub/values.yaml
@@ -198,7 +198,7 @@ daskhub:
     gateway:
       extraConfig:
         optionHandler: |
-          from dask_gateway_server.options import Options, String, Select, Mapping, Float, Bool
+          from dask_gateway_server.options import Options, Integer, String, Select, Mapping, Float, Bool
           from math import ceil
   
           def cluster_options(user):


### PR DESCRIPTION
Fixes an error introduced by #4  because we didn't import `Integer` in clusterOptions